### PR TITLE
feat: Implement user soft delete and inactive user login check

### DIFF
--- a/src/Libs/error.js
+++ b/src/Libs/error.js
@@ -13,6 +13,8 @@ const ERROR = {
   USER_ALREADY_EXISTS: () => { throw new CustomError({ message: 'User already exists', status: 409 }) },
   SERVICE_UNAVAILABLE: () => { throw new CustomError({ message: 'Service unavailable', status: 503 }) },
   PRODUCT_HAS_STOCK: () => { throw new CustomError({ message: 'Product has stock', status: 409 }) },
+  USER_INACTIVE: () => { throw new CustomError({ message:
+     'This user is not active, contact your administrator',status: 403 }) },
 }
 
 export default ERROR

--- a/src/Libs/error.js
+++ b/src/Libs/error.js
@@ -13,8 +13,7 @@ const ERROR = {
   USER_ALREADY_EXISTS: () => { throw new CustomError({ message: 'User already exists', status: 409 }) },
   SERVICE_UNAVAILABLE: () => { throw new CustomError({ message: 'Service unavailable', status: 503 }) },
   PRODUCT_HAS_STOCK: () => { throw new CustomError({ message: 'Product has stock', status: 409 }) },
-  USER_INACTIVE: () => { throw new CustomError({ message:
-     'This user is not active, contact your administrator',status: 403 }) },
+  USER_INACTIVE: () => { throw new CustomError({ message: 'This user is not active, contact your administrator', status: 403 }) },
 }
 
 export default ERROR

--- a/src/app/api/user/[id]/__tests__/userId.test.js
+++ b/src/app/api/user/[id]/__tests__/userId.test.js
@@ -18,30 +18,30 @@ vi.mock('~/app/api/Libs/prisma', () => {
             }
             : null
         ),
-        update: vi.fn(({ where, data }) =>
-          where.id === 1
-            ? {
+        update: vi.fn(({ where, data }) => {
+          if (where.id === 1) {
+            if (data && data.active === false) {
+              return {
+                id: 1,
+                name: 'Admin User',
+                username: 'admin',
+                role: 'ADMIN',
+                active: false,
+                createdAt: 'createdAt',
+                updatedAt: 'updatedAt',
+              }
+            }
+            return {
               id: 1,
               ...data,
               createdAt: 'createdAt',
-              updatedAt: 'updatedAt'
+              updatedAt: 'updatedAt',
             }
-            : null
-        ),
-        delete: vi.fn(({ where }) =>
-          where.id === 1
-            ? {
-              id: 1,
-              name: 'Admin User',
-              username: 'admin',
-              role: 'ADMIN',
-              createdAt: 'createdAt',
-              updatedAt: 'updatedAt'
-            }
-            : null
-        ),
-      }
-    }
+          }
+          return null
+        }),
+      },
+    },
   }
 })
 
@@ -227,22 +227,23 @@ describe('API User [id] - PATCH', () => {
 describe('API User [id] - DELETE', () => {
   it.each([
     {
-      descr: 'Successful delete',
+      descr: 'Successful soft delete',
       params: { id: 1 },
       expectedStatus: 200,
       expectedResponse: {
         id: 1,
         name: 'Admin User',
         username: 'admin',
-        role: 'ADMIN'
-      }
+        role: 'ADMIN',
+        active: false,
+      },
     },
     {
       descr: 'Error has not permission',
       params: { id: 1 },
       isNotAllowed: true,
       expectedStatus: 403,
-      expectedResponse: { error: 'Not allowed' }
+      expectedResponse: { error: 'Not allowed' },
     },
     {
       descr: 'Error not found',

--- a/src/app/api/user/[id]/route.js
+++ b/src/app/api/user/[id]/route.js
@@ -88,8 +88,9 @@ export const DELETE = async (request, { params }) => {
     const { id } = params
     if (!Number(id)) return ERROR.INVALID_FIELDS()
 
-    const payload = await prisma.user.delete({
-      where: { id: Number(id) }
+    const payload = await prisma.user.update({
+      where: { id: Number(id) },
+      data: { active: false }
     })
     if (!payload) return ERROR.NOT_FOUND()
     const response = cleanerData({ payload })

--- a/src/app/api/user/__tests__/user.test.js
+++ b/src/app/api/user/__tests__/user.test.js
@@ -6,30 +6,49 @@ vi.mock('~/app/api/Libs/prisma', () => {
   return {
     default: {
       user: {
-        findMany: () => ([
-          {
-            id: 1,
-            name: 'Admin User',
-            username: 'admin',
-            role: 'ADMIN',
-            createdAt: 'createdAt',
-            updatedAt: 'updatedAt',
-          },
-          {
-            id: 2,
-            name: 'Cashier User',
-            username: 'cashier',
-            role: 'CASHIER',
-            createdAt: 'createdAt',
-            updatedAt: 'updatedAt',
+        findMany: ({ where } = {}) => {
+          const allUsers = [
+            {
+              id: 1,
+              name: 'Admin User',
+              username: 'admin',
+              role: 'ADMIN',
+              active: true,
+              createdAt: 'createdAt',
+              updatedAt: 'updatedAt',
+            },
+            {
+              id: 2,
+              name: 'Cashier User',
+              username: 'cashier',
+              role: 'CASHIER',
+              active: true,
+              createdAt: 'createdAt',
+              updatedAt: 'updatedAt',
+            },
+            {
+              id: 3,
+              name: 'Inactive User',
+              username: 'inactive',
+              role: 'CASHIER',
+              active: false,
+              createdAt: 'createdAt',
+              updatedAt: 'updatedAt',
+            },
+          ]
+
+          if (where && where.active !== undefined) {
+            return allUsers.filter(user => user.active === where.active)
           }
-        ]),
+          return allUsers
+        },
         findUnique: () => null,
         create: ({ data }) => ({
           id: 1,
           name: data.name,
           username: data.username,
           role: data.role,
+          active: true,
           createdAt: 'createdAt',
           updatedAt: 'updatedAt',
         }),
@@ -53,14 +72,16 @@ describe('API User - GET', () => {
           name: 'Admin User',
           username: 'admin',
           role: 'ADMIN',
+          active: true,
         },
         {
           id: 2,
           name: 'Cashier User',
           username: 'cashier',
           role: 'CASHIER',
-        }
-      ]
+          active: true,
+        },
+      ],
     },
     {
       descr: 'Error has not permission',
@@ -116,6 +137,7 @@ describe('API User - POST', () => {
         name: 'New User',
         username: 'newuser',
         role: 'CASHIER',
+        active: true,
       }
     },
     {
@@ -140,7 +162,7 @@ describe('API User - POST', () => {
       },
       isNotAllowed: true,
       expectedStatus: 403,
-      expectedResponse: { error: 'Not allowed' }
+      expectedResponse: { error: 'Not allowed' },
     },
     {
       descr: 'Error invalid input',

--- a/src/app/api/user/login/__tests__/login.test.js
+++ b/src/app/api/user/login/__tests__/login.test.js
@@ -2,20 +2,20 @@
 import { describe, it, expect, vi } from 'vitest'
 import { POST } from '~/app/api/user/login/route'
 
-
 vi.mock('bcrypt', () => {
   return {
     default: {
-      compare: (inputPassword, realPassword) => inputPassword === realPassword ? true : false 
-    }
+      compare: (inputPassword, realPassword) =>
+        inputPassword === realPassword ? true : false,
+    },
   }
 })
 
 vi.mock('jsonwebtoken', () => {
   return {
     default: {
-      sign: () => 'successful token'
-    }
+      sign: () => 'successful token',
+    },
   }
 })
 
@@ -28,12 +28,11 @@ vi.mock('~/app/api/Libs/prisma', () => ({
         password: 'password',
         createdAt: 'createdAt',
         updatedAt: 'updatedAt',
-        active: 'active'
+        active: true,
       })
     }
   }
 }))
-
 
 describe('API User Login - POST', () => {
   it.each([
@@ -82,6 +81,16 @@ describe('API User Login - POST', () => {
       expectedResponse: { error: 'Invalid fields' }
     },
     {
+      descr: 'Error inactive user',
+      request: {
+        username: 'inactive_user',
+        password: 'password',
+      },
+      isInactive: true,
+      expectedStatus: 403,
+      expectedResponse: { error: 'This user is not active, contact your administrator' },
+    },
+    {
       descr: 'Error in database operation',
       request: {
         username: 'admin',
@@ -91,7 +100,7 @@ describe('API User Login - POST', () => {
       expectedStatus: 500,
       expectedResponse: { error: 'Database error' }
     }
-  ])('$descr', async ({ request, expectedStatus, expectedResponse, mockImplementation, isEmpty }) => {
+  ])('$descr', async ({ request, expectedStatus, expectedResponse, mockImplementation, isEmpty, isInactive }) => {
     if (mockImplementation) {
       const prisma = await import('~/app/api/Libs/prisma')
       vi.spyOn(prisma.default.user, 'findUnique').mockRejectedValueOnce(mockImplementation)
@@ -99,6 +108,17 @@ describe('API User Login - POST', () => {
     if (isEmpty){
       const prisma = await import('~/app/api/Libs/prisma')
       vi.spyOn(prisma.default.user, 'findUnique').mockReturnValueOnce(null)
+    }
+    if (isInactive) {
+      const prisma = await import('~/app/api/Libs/prisma')
+      vi.spyOn(prisma.default.user, 'findUnique').mockReturnValueOnce({
+        id: 1,
+        username: request.username,
+        password: 'password',
+        createdAt: 'createdAt',
+        updatedAt: 'updatedAt',
+        active: false,
+      })
     }
     const mockRequest = {
       json: async () => request,

--- a/src/app/api/user/login/route.js
+++ b/src/app/api/user/login/route.js
@@ -11,7 +11,8 @@ export const POST = async request => {
 
     const user = await prisma.user.findUnique({ where: { username } })
     if (!user) return ERROR.INVALID_FIELDS()
-
+    if (!user.active) return ERROR.USER_INACTIVE()
+      
     const isPasswordValid = await bcrypt.compare(password, user.password)
     if (!isPasswordValid) return ERROR.INVALID_FIELDS()
 

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -37,7 +37,9 @@ export const GET = async request => {
     const { role, userId } = authenticateToken(request) ?? {}
     if (role !== 'ADMIN' || !userId) return ERROR.FORBIDDEN()
 
-    const payloads = await prisma.user.findMany()
+    const payloads = await prisma.user.findMany({
+      where: { active: true },
+    })
     if (payloads.length === 0) return ERROR.NOT_FOUND()
     const response = payloads.map(payload => cleanerData({ payload }))
     return NextResponse.json(response, { status: 200 })


### PR DESCRIPTION
- User deletion now performs a soft delete by setting the 'active' flag to false instead of removing the record.
- The login route now blocks inactive users from logging in and returns a specific error.
- The User endpoint for retrieving all users now returns only active users.
- Corresponding tests have been updated to reflect this change.